### PR TITLE
Allow text line auto wrap in tags help frame

### DIFF
--- a/modules/Options.lua
+++ b/modules/Options.lua
@@ -4402,11 +4402,11 @@ function LunaUF:CreateOptionsMenu()
 			LunaOptionsFrame.helpframescrollchild.texts[count]:SetText("\124cffffff00".."["..k.."]\124cffffffff: "..v)
 			LunaOptionsFrame.helpframescrollchild.texts[count]:SetJustifyH("LEFT")
 			LunaOptionsFrame.helpframescrollchild.texts[count]:SetJustifyV("TOP")
-			if LunaOptionsFrame.helpframescrollchild.texts[count]:GetStringWidth() > 281 then
-				LunaOptionsFrame.helpframescrollchild.texts[count]:SetHeight(22)
-			else
-				LunaOptionsFrame.helpframescrollchild.texts[count]:SetHeight(11)
-			end
+-- 			if LunaOptionsFrame.helpframescrollchild.texts[count]:GetStringWidth() > 281 then
+-- 				LunaOptionsFrame.helpframescrollchild.texts[count]:SetHeight(22)
+-- 			else
+-- 				LunaOptionsFrame.helpframescrollchild.texts[count]:SetHeight(11)
+-- 			end
 			LunaOptionsFrame.helpframescrollchild.texts[count]:SetWidth(280)
 			if not first then
 				LunaOptionsFrame.helpframescrollchild.texts[count]:SetPoint("TOP", prevframe, "BOTTOM")


### PR DESCRIPTION
Currently, in tags help frame, line string will be cut if it is wider than the parent frame. This PR will fix this if this is not the design but bug.

Extra Information for others who need help about the font size:
1. If you see luna configuration dialog font size is smaller than the system, then you can change `LunaOptionsFrame:SetScale(0.8)` to `LunaOptionsFrame:SetScale(1)` in `modules\Options.lua`. This made me headache when i first used in my macOS.
2. If you want scale up the font size in every unit frame(like player/party etc) initially, you can change all `scale = 1` to `scale = 1.2` in `modules\defaults.lua`